### PR TITLE
Create keys dir if missing

### DIFF
--- a/roles/kms-data-key/tasks/main.yml
+++ b/roles/kms-data-key/tasks/main.yml
@@ -17,6 +17,10 @@
     --cli-input-json file://{{ cli_json }} \
     --key-spec {{ key_spec }}
   register: aws_output
+- name: Create key output directory if doesn't exist
+  file:
+    path: "{{ output | dirname }}"
+    state: directory
 - name: Output to file
   copy:
     content: "{{ aws_output.stdout }}"


### PR DESCRIPTION
Encountered error when trying this repo by itself. Command was:

```bash
ansible-playbook -i inventory -t generate_key --ask-vault-pass directory.yml
```

Error because `keys` directory is not created for the first time, so this is just a simple fix.